### PR TITLE
Hard error on some timeouted requests

### DIFF
--- a/src/httpclient.test.js
+++ b/src/httpclient.test.js
@@ -42,6 +42,10 @@ describe('HttpClient', () => {
       //
     } else if (req.url === '/timeout_with_data') {
       res.write('.')
+    } else if (req.url === '/timeout_with_late_response') {
+      setTimeout(() => {
+        res.end()
+      }, 101)
     } else if (req.url === '/large_response') {
       res.statusCode = 200
       res.end('x'.repeat(1024))
@@ -368,6 +372,17 @@ describe('HttpClient', () => {
     let response = httpClient.get(`${httpBaseUrl}/timeout_with_data`, null, {
       timeout: 100
     })
+    return expect(
+      response,
+      'to be rejected with error satisfying',
+      new HttpClientError('Timeout')
+    )
+  })
+
+  it('should timeout with long response time', async function() {
+    let httpClient = new HttpClient({ timeout: 100 })
+    let response = httpClient.get(`${httpBaseUrl}/timeout_with_late_response`)
+    await new Promise(resolve => setTimeout(resolve, 500))
     return expect(
       response,
       'to be rejected with error satisfying',


### PR DESCRIPTION
Stack trace:
```
TypeError: Cannot read property 'resolve' of undefined
    at IncomingMessage.responseStream.on (/app/node_modules/@connectedcars/httpclient/src/httpclient.js:568:34)
    at IncomingMessage.emit (events.js:187:15)
    at endReadableNT (_stream_readable.js:1081:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

I have added a test reproducing the issue.